### PR TITLE
Syntax error and typo fix

### DIFF
--- a/README
+++ b/README
@@ -37,11 +37,11 @@ Set up Varnish >= 2.1.x and then:
 $ cd vcl/
 $ make
 $ cd ..
-$ ln -s $PWD/vcl/ /etc/varnish/security.vcl/ 
+$ ln -s $PWD/vcl/ /etc/varnish/security/
 
 then you edit your default.vcl and add this line near the top:
 
-	include "/etc/varnish/security.vcl/main.vcl";
+	include "/etc/varnish/security/main.vcl";
 
 At this point, you should only need to reload your varnish configuration.
 

--- a/vcl/modules/cloak.vcl
+++ b/vcl/modules/cloak.vcl
@@ -20,9 +20,8 @@ sub vcl_recv {
    set req.http.X-SEC-Module = "cloak";
    
    # I'm sure there are other urls you can try Erik
-   if (req.version ~
    if (req.url ~ "^/%250?$"){
-      set req.http.X-SEC-RuleName = "Bogous request";
+      set req.http.X-SEC-RuleName = "Bogus request";
       set req.http.X-SEC-RuleId = "1";
       set req.http.X-SEC-RuleInfo = "Htrosbif specific";
       # htrosbif attacks! lets try to confuse it


### PR DESCRIPTION
This fixes an error where Varnish will refuse to compile the VCL with this included.

There is also an error in the install instructions, and a small typo fix.
